### PR TITLE
Add initial FuseSoC support

### DIFF
--- a/configs/swerv_config_gen.py
+++ b/configs/swerv_config_gen.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+from fusesoc.capi2.generator import Generator
+import os
+import shutil
+import subprocess
+import tempfile
+
+class SwervConfigGenerator(Generator):
+    def run(self):
+        files = [
+            {"configs/snapshots/default/common_defines.vh" : {
+                "copyto"    : "config/common_defines.vh",
+                "file_type" : "systemVerilogSource"}},
+            {"configs/snapshots/default/pic_ctrl_verilator_unroll.sv" : {
+                "copyto" : "config/pic_ctrl_verilator_unroll.sv",
+                "is_include_file" : True,
+                "file_type" : "systemVerilogSource"}},
+            {"configs/snapshots/default/pic_map_auto.h" : {
+                "copyto" : "config/pic_map_auto.h",
+                "is_include_file" : True,
+                "file_type" : "systemVerilogSource"}}]
+
+        tmp_dir = os.path.join(tempfile.mkdtemp(), 'core')
+        shutil.copytree(self.files_root, tmp_dir)
+
+        cwd = tmp_dir
+
+        env = os.environ.copy()
+        env['RV_ROOT'] = tmp_dir
+        args = ['configs/swerv.config'] + self.config.get('args', [])
+        rc = subprocess.call(args, cwd=cwd, env=env)
+        if rc:
+            exit(1)
+
+        filenames = []
+        for f in files:
+            for k in f:
+                filenames.append(k)
+
+        for f in filenames:
+            d = os.path.dirname(f)
+            if d and not os.path.exists(d):
+                os.makedirs(d)
+            shutil.copy2(os.path.join(cwd, f),f)
+
+        self.add_files(files)
+
+g = SwervConfigGenerator()
+g.run()
+g.write()

--- a/design/lsu/lsu_bus_read_buffer.sv
+++ b/design/lsu/lsu_bus_read_buffer.sv
@@ -149,6 +149,7 @@ module lsu_bus_read_buffer (
 
    state_t [DEPTH-1:0]       busfifo_state;
    state_t [DEPTH-1:0]       busfifo_nxtstate;
+   logic   [DEPTH-1:0][2:0]  busfifo_state_dout;
    logic   [DEPTH-1:0]       busfifo_block;
    logic   [DEPTH-1:0]       busfifo_dual;
    logic   [DEPTH-1:0]       busfifo_nb;
@@ -347,8 +348,9 @@ module lsu_bus_read_buffer (
          endcase
       end
 
+   assign busfifo_state[i] = state_t'(busfifo_state_dout[i]);
       //rvdffsc #(.WIDTH($bits(state_t))) busfifo_state_ff (.din(busfifo_nxtstate[i]), .dout({busfifo_state[i]}), .sel(busfifo_state_en[i]), .clear(busfifo_rst), .clk(lsu_free_c2_clk), .*);
-      rvdffsc #(.WIDTH($bits(state_t))) busfifo_state_ff (.din(busfifo_nxtstate[i]), .dout({busfifo_state[i]}), .en(busfifo_state_en[i]), .clear(busfifo_rst[i]), .clk(lsu_free_c2_clk), .*);
+      rvdffsc #(.WIDTH($bits(state_t))) busfifo_state_ff (.din(busfifo_nxtstate[i]), .dout(busfifo_state_dout[i]), .en(busfifo_state_en[i]), .clear(busfifo_rst[i]), .clk(lsu_free_c2_clk), .*);
       rvdffsc  #(.WIDTH(1)) busfifo_blockff (.din(lsu_read_buffer_block_dc3), .dout(busfifo_block[i]), .en(busfifo_wr_en[i]), .clear(busfifo_block_rst[i]), .clk(lsu_rdbuf_c1_clk), .*);  // Stall the entry till write buffer is empty
       rvdffs  #(.WIDTH(1)) busfifo_dualff (.din(ldst_dual_dc3), .dout(busfifo_dual[i]), .en(busfifo_wr_en[i]), .clk(lsu_rdbuf_c1_clk), .*);
       rvdffs  #(.WIDTH(1)) busfifo_nbff (.din(lsu_nonblock_load_valid_dc3), .dout(busfifo_nb[i]), .en(busfifo_wr_en[i]), .clk(lsu_rdbuf_c1_clk), .*);

--- a/design/lsu/lsu_bus_write_buffer.sv
+++ b/design/lsu/lsu_bus_write_buffer.sv
@@ -157,6 +157,7 @@ module lsu_bus_write_buffer (
    
    state_t [DEPTH-1:0]       busfifo_state;
    state_t [DEPTH-1:0]       busfifo_nxtstate;
+   logic [DEPTH-1:0][2:0]    busfifo_state_dout;
    logic [DEPTH-1:0]         busfifo_state_en;
    logic [DEPTH-1:0]         busfifo_bus_state_en;
 
@@ -488,8 +489,9 @@ module lsu_bus_write_buffer (
             end
          endcase
       end
-  
-      rvdffs #(.WIDTH(3)) busfifo_state_ff (.din(busfifo_nxtstate[i]), .dout({busfifo_state[i]}), .en(busfifo_state_en[i]), .clk(lsu_free_c2_clk), .*);
+
+   assign busfifo_state[i] = state_t'(busfifo_state_dout[i]);
+      rvdffs #(.WIDTH(3)) busfifo_state_ff (.din(busfifo_nxtstate[i]), .dout(busfifo_state_dout[i]), .en(busfifo_state_en[i]), .clk(lsu_free_c2_clk), .*);
       rvdffe #(.WIDTH(32)) busfifo_addrff (.din(busfifo_addr_in[i]), .dout(busfifo_addr[i]), .en(busfifo_wr_en[i]), .*);
       rvdffs #(.WIDTH(8)) busfifo_byteenff (.din(busfifo_byteen_in[i]), .dout(busfifo_byteen[i]), .en(busfifo_wr_en[i]), .clk(lsu_wrbuf_c1_clk), .*);
       rvdffs #(.WIDTH(2)) busfifo_sizeff (.din(busfifo_size_in[i]), .dout(busfifo_size[i]), .en(busfifo_wr_en[i]), .clk(lsu_wrbuf_c1_clk), .*);

--- a/swerv.core
+++ b/swerv.core
@@ -1,0 +1,136 @@
+CAPI=2:
+
+name : ::swerv:0
+
+filesets:
+  rtl:
+    files:
+      - design/lib/beh_lib.sv
+      - design/mem.sv
+      - design/pic_ctrl.sv
+      - design/dma_ctrl.sv
+      - design/ifu/ifu_aln_ctl.sv
+      - design/ifu/ifu_compress_ctl.sv
+      - design/ifu/ifu_ifc_ctl.sv
+      - design/ifu/ifu_bp_ctl.sv
+      - design/ifu/ifu_ic_mem.sv
+      - design/ifu/ifu_mem_ctl.sv
+      - design/ifu/ifu_iccm_mem.sv
+      - design/ifu/ifu.sv
+      - design/dec/dec_decode_ctl.sv
+      - design/dec/dec_gpr_ctl.sv
+      - design/dec/dec_ib_ctl.sv
+      - design/dec/dec_tlu_ctl.sv
+      - design/dec/dec_trigger.sv
+      - design/dec/dec.sv
+      - design/exu/exu_alu_ctl.sv
+      - design/exu/exu_mul_ctl.sv
+      - design/exu/exu_div_ctl.sv
+      - design/exu/exu.sv
+      - design/lsu/lsu.sv
+      - design/lsu/lsu_clkdomain.sv
+      - design/lsu/lsu_addrcheck.sv
+      - design/lsu/lsu_lsc_ctl.sv
+      - design/lsu/lsu_stbuf.sv
+      - design/lsu/lsu_bus_read_buffer.sv
+      - design/lsu/lsu_bus_write_buffer.sv
+      - design/lsu/lsu_bus_intf.sv
+      - design/lsu/lsu_ecc.sv
+      - design/lsu/lsu_dccm_mem.sv
+      - design/lsu/lsu_dccm_ctl.sv
+      - design/lsu/lsu_trigger.sv
+      - design/dbg/dbg.sv
+      - design/dmi/dmi_wrapper.v
+      - design/dmi/dmi_jtag_to_core_sync.v
+      - design/dmi/rvjtag_tap.v
+      - design/dmi/double_flop_sync.v
+      - design/dmi/toggle_sync.v
+      - design/lib/mem_lib.sv
+      - design/lib/ahb_to_axi4.sv
+      - design/lib/axi4_to_ahb.sv
+      - design/swerv.sv
+      - design/swerv_wrapper.sv
+    file_type : systemVerilogSource
+
+  includes:
+    files:
+      - design/include/build.h : {is_include_file : true}
+      - design/include/global.h : {is_include_file : true}
+    file_type : systemVerilogSource
+
+  def_is_user:
+    files: [design/include/def.sv : {copyto : include/def.sv, file_type : user}]
+
+  def_is_sv:
+    files: [design/include/def.sv : {copyto : include/def.sv, file_type : systemVerilogSource}]
+
+  mem_init:
+    files:
+      - testbench/hex/data.hex : {copyto : data.hex}
+      - testbench/hex/program.hex : {copyto : program.hex}
+    file_type : user
+
+  tb:
+    files: [testbench/ahb_sif.sv, testbench/tb_top.sv]
+    file_type : systemVerilogSource
+
+  verilator_tb:
+    files : [testbench/test_tb_top.cpp : {file_type : cppSource}]
+
+  vivado_tcl:
+    files: [vivado.tcl : {file_type : tclSource}]
+
+targets:
+  lint:
+    default_tool: verilator
+    filesets : [includes, def_is_sv, rtl]
+    generate : [swerv_default_config]
+    tools:
+      verilator :
+        mode : lint-only
+        verilator_options : [-UASSERT_ON]
+    toplevel : swerv_wrapper
+
+  sim:
+    default_tool : verilator
+    filesets :
+      - includes
+      - "tool_modelsim ? (def_is_user)"
+      - "!tool_modelsim ? (def_is_sv)"
+      - rtl
+      - mem_init
+      - tb
+      - "tool_verilator? (verilator_tb)"
+
+    generate : [swerv_default_config]
+    tools:
+      modelsim:
+        vlog_options :
+          - -mfcu
+          - -cuautoname=du
+          - config/common_defines.vh
+          - include/def.sv
+      verilator:
+        verilator_options : [--trace]
+    toplevel : tb_top
+
+  synth:
+    default_tool : vivado
+    filesets : [includes, def_is_sv, rtl, vivado_tcl]
+    generate : [swerv_default_config]
+    tools:
+      vivado:
+        part : xc7a100tcsg324-1
+    toplevel : swerv_wrapper
+
+generate:
+  swerv_default_config:
+    generator: swerv_config
+    position : first
+    parameters:
+      args : ['-ahb_lite']
+generators:
+  swerv_config:
+    interpreter: python
+    command: configs/swerv_config_gen.py
+    description : Create a SweRV configuration. Note! Only supports the default config

--- a/vivado.tcl
+++ b/vivado.tcl
@@ -1,0 +1,2 @@
+set_property is_global_include true [get_files config/common_defines.vh]
+set_property IS_GLOBAL_INCLUDE 1 [get_files include/def.sv]


### PR DESCRIPTION
This series fixes a syntactic issue for modelsim and adds initial FuseSoC support

How to use
1. Install FuseSoC with `pip install fusesoc`
2. Create an empty workspace directory
3. From the workspace directory run `fusesoc library add swerv /path/to/repo` to register SweRV as a library
4. Run one of the swerv targets from the workspace directory

The following targets are supported so far

Linting with verilator: `$ fusesoc run --target=lint swerv`

Simulate the bundled test program with modelsim or verilator `$ fusesoc run --target=sim --tool={modelsim,verilator} swerv`

Run synthesis with Vivado: `$ fusesoc run --target=synth swerv`

Also includes a generator for the SweRV config