### PR TITLE
Fix swerv.config help for ret_stack_size

### DIFF
--- a/configs/swerv.config
+++ b/configs/swerv.config
@@ -99,7 +99,7 @@ User options:
 
 Additional direct options for the following variables:
 
-     -ret_size =      {2, 3, 4, ... 8}
+     -ret_stack_size ={2, 3, 4, ... 8}
         size of return stack
      -btb_size =      { 32, 48, 64, 128, 256, 512 }
         size of branch target buffer


### PR DESCRIPTION
When running `swerv.config -h`, you get the following:

```
Additional direct options for the following variables:

     -ret_size =      {2, 3, 4, ... 8}
        size of return stack
```

In reality, the tool expects `-ret_stack_size` instead of `-ret_size`.