### PR TITLE
Update .gitignore to ignore Makefile-created files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 configs/snapshots
 work
+obj_dir
+*.vcd
+*.csv
+*.hex
+*.log


### PR DESCRIPTION
Please consider the attached patch. This updates .gitignore so that "git status" will be empty after building a model following the README. Thanks.
