### PR TITLE
Fix Verilator future duplicate declaration error

### DIFF
--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -22,6 +22,7 @@ module tb_top ( input logic core_clk, input logic reset_l, output finished);
 `ifndef VERILATOR
    logic                                reset_l;
    logic                                core_clk;
+   logic                                finished;
 `endif
    logic                                nmi_int;
 
@@ -100,7 +101,6 @@ module tb_top ( input logic core_clk, input logic reset_l, output finished);
 
    logic        [31:0]                  cycleCnt       ;
    logic                                mailbox_data_val;
-   logic                                finished;
 
    wire                                 dma_hready_out;
 


### PR DESCRIPTION
Please accept the following repair to be able to continue to Verilate.

Verilator had a bug whereby some duplicate variables were not being reported as errors. This will soon be fixed, and this uncovered that the finished signal was declared twice, which this patch fixes.

