### PR TITLE
Fix link to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SweRV RISC-V Core<sup>TM</sup> 1.1 from Western Digital
 
-This repository is deprecated. Please use the [Chip Alliance repository](https://githib.com/chipalliance/Cores-SwerV).
+This repository is deprecated. Please use the [Chip Alliance repository](https://github.com/chipsalliance/Cores-SweRV).
 
 This repository contains the SweRV Core<sup>TM</sup> version 1.1 design
 RTL. This is a mirror repository. The main repository is in the [Chip


### PR DESCRIPTION
The link to the new repo (in the chipsalliance github) is broken.